### PR TITLE
fix devise signup error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name])
+  end
+
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,17 +11,25 @@
                 <%= f.error_notification %>
 
                 <div class="form-inputs">
-                  <%= f.input :email,
-                              required: true,
-                              autofocus: true, placeholder: "Your email here",
-                              input_html: { autocomplete: "email" }%>
-                  <%= f.input :password,
-                              required: true, placeholder: "Your password here",
-                              hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                              input_html: { autocomplete: "new-password" } %>
-                  <%= f.input :password_confirmation,
-                              required: true, placeholder: "Your password here",
-                              input_html: { autocomplete: "new-password" } %>
+                  <%= f.input :first_name,
+                                required: true,
+                                autofocus: true, placeholder: "Your first name",
+                                input_html: { autocomplete: "email" }%>
+                  <%= f.input :last_name,
+                                required: true,
+                                autofocus: true, placeholder: "Your last name",
+                                input_html: { autocomplete: "email" }%>
+                    <%= f.input :email,
+                                required: true,
+                                autofocus: true, placeholder: "Your email here",
+                                input_html: { autocomplete: "email" }%>
+                    <%= f.input :password,
+                                required: true, placeholder: "Your password here",
+                                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+                                input_html: { autocomplete: "new-password" } %>
+                    <%= f.input :password_confirmation,
+                                required: true, placeholder: "Your password here",
+                                input_html: { autocomplete: "new-password" } %>
                 </div>
 
                 <div class="form-actions">


### PR DESCRIPTION
fix devise signup error
add params in application controller:

class ApplicationController < ActionController::Base
  before_action :configure_permitted_parameters, if: :devise_controller?
  before_action :authenticate_user!

  def configure_permitted_parameters
    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name])
    devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name])
  end

end